### PR TITLE
feat: make ns selector label configurable

### DIFF
--- a/charts/envars-webhook/templates/mutatingwebhook.yaml
+++ b/charts/envars-webhook/templates/mutatingwebhook.yaml
@@ -24,7 +24,7 @@ webhooks:
       caBundle: {{ $ca.Cert | b64enc }}
     namespaceSelector:
       matchLabels:
-        name: {{ .Values.webhook.namespaceSelector }}
+        {{ .Values.webhook.namespaceSelectorLabel | default "name" }}: {{ .Values.webhook.namespaceSelector }}
     rules:
       - operations: [ "CREATE", "UPDATE", "DELETE" ]
         apiGroups: [""]

--- a/charts/envars-webhook/values.yaml
+++ b/charts/envars-webhook/values.yaml
@@ -37,7 +37,8 @@ service:
   type: ClusterIP
   port: 443
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -61,11 +62,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-  
+
 # Webhook settings
 webhook:
   # The namespace that the webhook would accept requests from
   namespaceSelector: samples
+  # The label to use for selecting namespace
+  # namespaceSelectorLabel: name
   # Show the JSON body for requests and responses in webhook logs
   verboseLogs: false
   # Map of container names allowed to receive node labels. False value or missing container name means node labels are not exposed.


### PR DESCRIPTION
Makes namespace selector labels configurable.

```
❯ helm upgrade --install -n dev envars-webhook charts/envars-webhook --set webhook.namespaceSelector=dev --set webhook.namespaceSelectorLabel=kubernetes.io/metadata.name --set webhook.verboseLogs=false --set webhook.containersAllowed.foundationdb=true
Release "envars-webhook" has been upgraded. Happy Helming!
NAME: envars-webhook
LAST DEPLOYED: Fri Dec 16 15:49:07 2022
NAMESPACE: dev
STATUS: deployed
REVISION: 3
TEST SUITE: None
NOTES:
***********************************************************************
*  envars-webhook installed !                                         *
***********************************************************************
  Chart version: 0.1.5
  App version:   0.1.0
  Image repo     ghcr.io/danfromtitan/envars-from-node-labels
  Image tag:     latest
***********************************************************************

Verify the admission controller is working by running these commands:
  kubectl get secret -n dev envars-webhook-tls -o 'go-template={{index .data "tls.crt"}}' | base64 -d | openssl x509 -text -noout
  kubectl get pods -n dev
  kubectl logs -f -n dev pod-name
  kubectl get mutatingwebhookconfigurations envars-webhook -o yaml
```

```
❯   kubectl get mutatingwebhookconfigurations envars-webhook -o yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-delete-policy: before-hook-creation
  creationTimestamp: "2022-12-08T16:16:09Z"
  generation: 2
  labels:
    app.kubernetes.io/instance: envars-webhook
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: envars-webhook
    app.kubernetes.io/version: 0.1.0
    helm.sh/chart: envars-webhook-0.1.5
  name: envars-webhook
  resourceVersion: "188202624"
  uid: 4c3ffdfa-56f0-432c-9e65-19335bbf38d4
webhooks:
- admissionReviewVersions:
  - v1
  clientConfig:
    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUROakNDQWg2Z0F3SUJBZ0lSQUtDK3paY3o5bWptQjlRdXg5d2RoNmd3RFFZSktvWklodmNOQVFFTEJRQXcKSlRFak1DRUdBMVVFQXhNYVpXNTJZWEp6TFhkbFltaHZiMnN0Y205dmRDMWpZUzVrWlhZd0hoY05Nakl4TWpBNApNVFl4TmpBMldoY05Nekl4TWpBMU1UWXhOakEyV2pBbE1TTXdJUVlEVlFRREV4cGxiblpoY25NdGQyVmlhRzl2CmF5MXliMjkwTFdOaExtUmxkakNDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFOTHYKbFZYYllUVDRTOVNMSUZxeTUzZzhQa25XOFVvWnJqNmZrUGhaaUcrZTBvcEJqc1h3OGFCd1EvNnExS1pEOERRbQoyZmZOcTFST01LR1U1TEorMmo2TXkzVXFDdnJoQkF0UXJTMW96S3c2cU0rNmsxN2o2YkxKQThCWFJwbjlLd0VzCjBseWtnQnN1U1NCUHN2OGFzYVdBK29mTzhuWEQ4WC9hWUVlZHVNNktqM2lGRVFjNjU1bnVKTVdaQ1VFRks0TXoKeEJmdkhCT1RNQU1mZXd3aEJVaFdyb2p2djFXRW1PRTF6Z3hNMU55R3F5WHlJbWRGazM3RzkraHhxd3VLQW1VagpUWXZJd2dBdDJVNkVCZlp1aWdKU1lUR0pWM0grRXhVZmNaRG9IbWU0Q3ZGNDhTU2g5ZzdmZEdxeEVJZGpwTVhWCnY1RmtibThJMnp0VE4ybWdmWDhDQXdFQUFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVcKTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRVwpCQlQvMU9PZmp3eXFJN2hzRVloZXlVRmVnT0VkVFRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXNYS1QvSnhUCkppR0tGdlcxdXNuQ3h4MVdXcjc0bGpuZjN1REk0eGl0K0NNQmhidnhSZGdjbGNtaG1zRDJOeDFNaXNoajJoRkgKWm16YjNyc3lodHF5TkNIcDdHWVBKckQ0RzR2UkhSaytwSFBOK3pleWQ3czlSNjFXS3Axalh5MnhYeDhIM1FXRgorbEJWcmVsN0dUY2Y4WFlsM1lsR1JVOHRacG1DVmJPMkJjL2ZYbTRtSzRTRStrbHpjNXBwMWlTazZlZmxaUXp5CkJDUGdyRFBuVEFTbTVtWithZGg5dnRIaTc3aGJWU3VXekRWczJzSkhUUFBVdEJ2bC8vK21Hbm9TSHRwNXVORWgKTjhyZmtlK3I1QmZoSDBaeHYzbnJjT1hNV2ZQNnA0Rm9jbC9HUWw4TWFRdU9HS241S3RrbUhVM21BNldFdlJRKwpHNzdqM2tId1hzanAyUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
    service:
      name: envars-webhook
      namespace: dev
      path: /mutate
      port: 443
  failurePolicy: Fail
  matchPolicy: Equivalent
  name: envars-webhook.dev.svc
  namespaceSelector:
    matchLabels:
      kubernetes.io/metadata.name: dev
  objectSelector: {}
  reinvocationPolicy: Never
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    - UPDATE
    - DELETE
    resources:
    - pods
    - pods/binding
    scope: '*'
  sideEffects: None
  timeoutSeconds: 30
  ```